### PR TITLE
Make build working with JDK 8, 11 and 14 (at a minimum)

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -1910,9 +1910,9 @@ public class ASTHelpers {
 
     @Override
     public Void visitMethodInvocation(MethodInvocationTree invocation, Void unused) {
-      MethodSymbol symbol = getSymbol(invocation);
-      if (symbol != null) {
-        getThrownTypes().addAll(symbol.getThrownTypes());
+      Type type = getType(invocation.getMethodSelect());
+      if (type != null) {
+        getThrownTypes().addAll(type.getThrownTypes());
       }
       return super.visitMethodInvocation(invocation, null);
     }

--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -1067,11 +1067,15 @@ public class ASTHelpers {
     return types.isSubtype(types.erasure(s), types.erasure(t));
   }
 
-  /** Returns true if {@code t} is a subtype of Exception but not a subtype of RuntimeException. */
+  /**
+   * Returns true if {@code t} is a subtype of Throwable but not a subtype of RuntimeException or
+   * Error.
+   */
   public static boolean isCheckedExceptionType(Type t, VisitorState state) {
     Symtab symtab = state.getSymtab();
-    return isSubtype(t, symtab.exceptionType, state)
-        && !isSubtype(t, symtab.runtimeExceptionType, state);
+    return isSubtype(t, symtab.throwableType, state)
+        && !isSubtype(t, symtab.runtimeExceptionType, state)
+        && !isSubtype(t, symtab.errorType, state);
   }
 
   /** Returns true if {@code erasure(s)} is castable to {@code erasure(t)}. */

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -351,6 +351,11 @@
       <version>1.0.5</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.threeten</groupId>
+      <artifactId>threeten-extra</artifactId>
+      <version>1.5.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -406,7 +406,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
         <configuration>
           <!-- set heap size to work around http://github.com/travis-ci/travis-ci/issues/3396 -->
           <argLine>-Xmx1g</argLine>
@@ -464,7 +463,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.19.1</version>
             <configuration>
               <forkCount>4</forkCount>
               <reuseForks>true</reuseForks>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -485,15 +485,6 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <excludes>
-                <exclude>com/google/errorprone/refaster/UInstanceOf.java</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
             <executions>
               <execution>
@@ -501,13 +492,29 @@
                 <phase>compile</phase>
                 <configuration>
                   <tasks>
-                    <property name="compile_classpath" refid="maven.compile.classpath"/>
+                    <pathconvert property="compile_classpath" refid="maven.compile.classpath" pathsep="," />
                     <mkdir dir="${java14.build.outputDirectory}" />
+                    <mkdir dir="${java14.generatedSourcesDirectory}" />
+                    <!-- can't use release="14" (the reason we cannot use the maven-compiler-plugin either) because we reference internal JDK classes -->
                     <javac
+                        source="14" target="14"
                         srcdir="${java14.sourceDirectory}"
                         destdir="${java14.build.outputDirectory}"
-                        classpath="${compile_classpath}"
-                        includeantruntime="false" />
+                        includeantruntime="false"
+                        sourcepath="">
+                      <classpath>
+                        <files includes="${compile_classpath}"
+                            excludes="${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar" />
+                      </classpath>
+                      <compilerarg value="-s" />
+                      <compilerarg file="${java14.generatedSourcesDirectory}" />
+                      <compilerarg value="--add-exports" />
+                      <compilerarg value="jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED" />
+                      <compilerarg value="--add-exports" />
+                      <compilerarg value="jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" />
+                      <compilerarg value="--add-exports" />
+                      <compilerarg value="jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED" />
+                    </javac>
                   </tasks>
                 </configuration>
                 <goals>
@@ -515,6 +522,17 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <configuration>
+              <archive>
+                <manifestEntries>
+                  <Multi-Release>true</Multi-Release>
+                </manifestEntries>
+              </archive>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -407,6 +407,28 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <!-- Run tests with failsafe to use the Multi-Release JAR -->
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <!-- this is the default pattern of maven-surefire-plugin -->
+          <includes>
+            <include>**/Test*.java</include>
+            <include>**/*Test.java</include>
+            <include>**/*TestCase.java</include>
+          </includes>
           <!-- set heap size to work around http://github.com/travis-ci/travis-ci/issues/3396 -->
           <argLine>-Xmx1g</argLine>
         </configuration>
@@ -462,7 +484,7 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
+            <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
               <forkCount>4</forkCount>
               <reuseForks>true</reuseForks>

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TruthGetOrDefault.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TruthGetOrDefault.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.Objects;
+
+/**
+ * Flags ambiguous usages of {@code Map#getOrDefault} within {@code Truth#assertThat}.
+ *
+ * @author bhagwani@google.com (Sumit Bhagwani)
+ */
+@BugPattern(
+    name = "TruthGetOrDefault",
+    summary = "Asserting on getOrDefault is unclear; prefer containsEntry or doesNotContainKey",
+    severity = WARNING)
+public final class TruthGetOrDefault extends BugChecker implements MethodInvocationTreeMatcher {
+
+  private static final Matcher<ExpressionTree> ASSERT_THAT =
+      staticMethod().onClass("com.google.common.truth.Truth").named("assertThat");
+
+  private static final Matcher<ExpressionTree> GET_OR_DEFAULT_MATCHER =
+      instanceMethod().onDescendantOf("java.util.Map").named("getOrDefault");
+
+  private static final Matcher<ExpressionTree> SUBJECT_EQUALS_MATCHER =
+      instanceMethod()
+          .onDescendantOf("com.google.common.truth.Subject")
+          .named("isEqualTo")
+          .withParameters("java.lang.Object");
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (!SUBJECT_EQUALS_MATCHER.matches(tree, state)) {
+      return Description.NO_MATCH;
+    }
+    ExpressionTree rec = ASTHelpers.getReceiver(tree);
+    if (rec == null) {
+      return Description.NO_MATCH;
+    }
+    if (!ASSERT_THAT.matches(rec, state)) {
+      return Description.NO_MATCH;
+    }
+    ExpressionTree arg = getOnlyElement(((MethodInvocationTree) rec).getArguments());
+    if (!GET_OR_DEFAULT_MATCHER.matches(arg, state)) {
+      return Description.NO_MATCH;
+    }
+    MethodInvocationTree argMethodInvocationTree = (MethodInvocationTree) arg;
+    ExpressionTree defaultVal = argMethodInvocationTree.getArguments().get(1);
+    ExpressionTree expectedVal = getOnlyElement(tree.getArguments());
+    Match match = areValuesSame(defaultVal, expectedVal, state);
+    switch (match) {
+      case UNKNOWN:
+        return Description.NO_MATCH;
+      case DIFFERENT:
+        return describeMatch(
+            tree,
+            SuggestedFix.builder()
+                .replace(
+                    argMethodInvocationTree,
+                    state.getSourceForNode(ASTHelpers.getReceiver(argMethodInvocationTree)))
+                .replace(
+                    state.getEndPosition(rec),
+                    state.getEndPosition(tree.getMethodSelect()),
+                    ".containsEntry")
+                .replace(
+                    tree.getArguments().get(0),
+                    state.getSourceForNode(argMethodInvocationTree.getArguments().get(0))
+                        + ", "
+                        + state.getSourceForNode(tree.getArguments().get(0)))
+                .build());
+      case SAME:
+        return describeMatch(
+            tree,
+            SuggestedFix.builder()
+                .replace(arg, state.getSourceForNode(ASTHelpers.getReceiver(arg)))
+                .replace(
+                    state.getEndPosition(rec),
+                    state.getEndPosition(tree.getMethodSelect()),
+                    ".doesNotContainKey")
+                .replace(
+                    tree.getArguments().get(0),
+                    state.getSourceForNode(argMethodInvocationTree.getArguments().get(0)))
+                .build());
+    }
+    return Description.NO_MATCH;
+  }
+
+  private enum Match {
+    SAME,
+    DIFFERENT,
+    UNKNOWN;
+  }
+
+  /**
+   * Returns {@code Match.SAME} or {@code Match.DIFFERENT} when it can confidently say that both
+   * expressions are same or different, otherwise returns {@code Match.UNKNOWN}.
+   */
+  private static Match areValuesSame(
+      ExpressionTree defaultVal, ExpressionTree expectedVal, VisitorState state) {
+    if (ASTHelpers.sameVariable(defaultVal, expectedVal)) {
+      return Match.SAME;
+    }
+    Object expectedConstVal = ASTHelpers.constValue(expectedVal);
+    Object defaultConstVal = ASTHelpers.constValue(defaultVal);
+    if (expectedConstVal == null || defaultConstVal == null) {
+      return Match.UNKNOWN;
+    }
+    if (Objects.equals(defaultConstVal, expectedConstVal)) {
+      return Match.SAME;
+    }
+    if (!state
+        .getTypes()
+        .isSameType(ASTHelpers.getType(expectedVal), ASTHelpers.getType(defaultVal))) {
+      return Match.UNKNOWN;
+    }
+    return Match.DIFFERENT;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualified.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualified.java
@@ -159,7 +159,7 @@ public final class UnnecessarilyFullyQualified extends BugChecker
       }
       List<TreePath> pathsToFix = getOnlyElement(types.values());
       if (pathsToFix.stream()
-          .anyMatch(path -> findIdent(name.toString(), state, VAL_TYP) != null)) {
+          .anyMatch(path -> findIdent(name.toString(), state.withPath(path), VAL_TYP) != null)) {
         continue;
       }
       SuggestedFix.Builder fixBuilder = SuggestedFix.builder();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/AbstractCollectionIncompatibleTypeMatcher.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/AbstractCollectionIncompatibleTypeMatcher.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
  * Extracts the necessary information from a {@link MethodInvocationTree} to check whether calls to
  * a method are using incompatible types and to emit a helpful error message.
  */
-abstract class AbstractCollectionIncompatibleTypeMatcher {
+public abstract class AbstractCollectionIncompatibleTypeMatcher {
 
   /**
    * Returns a matcher for the appropriate method invocation for this matcher. For example, this
@@ -101,8 +101,12 @@ abstract class AbstractCollectionIncompatibleTypeMatcher {
   @Nullable
   abstract Type extractTargetType(MemberReferenceTree tree, VisitorState state);
 
+  /**
+   * Encapsulates the result of matching a {@link Collection#contains}-like call, including the
+   * source and target types.
+   */
   @AutoValue
-  abstract static class MatchResult {
+  public abstract static class MatchResult {
     public abstract ExpressionTree sourceTree();
 
     public abstract Type sourceType();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/ContainmentMatchers.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/ContainmentMatchers.java
@@ -111,7 +111,7 @@ public final class ContainmentMatchers {
           .build();
 
   @Nullable
-  static MatchResult firstNonNullMatchResult(ExpressionTree tree, VisitorState state) {
+  public static MatchResult firstNonNullMatchResult(ExpressionTree tree, VisitorState state) {
     if (!FIRST_ORDER_MATCHER.matches(tree, state)) {
       return null;
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/FromTemporalAccessor.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/FromTemporalAccessor.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.isSameType;
+import static com.google.errorprone.matchers.Matchers.packageStartsWith;
+import static com.google.errorprone.matchers.Matchers.staticMethod;
+import static com.google.errorprone.util.ASTHelpers.getReceiverType;
+import static com.google.errorprone.util.ASTHelpers.getType;
+import static com.google.errorprone.util.ASTHelpers.isSameType;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Type;
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.threeten.extra.AmPm;
+import org.threeten.extra.DayOfMonth;
+import org.threeten.extra.DayOfYear;
+import org.threeten.extra.Quarter;
+import org.threeten.extra.YearQuarter;
+import org.threeten.extra.YearWeek;
+
+/**
+ * Bans calls to {@code javaTimeType.from(temporalAmount)} where the call is guaranteed to either:
+ *
+ * <ul>
+ *   <li>throw a {@code DateTimeException} at runtime (e.g., {@code LocalDate.from(month)})
+ *   <li>return the same parameter (e.g., {@code Instant.from(instant)})
+ * </ul>
+ *
+ * @author kak@google.com (Kurt Alfred Kluever)
+ */
+@BugPattern(
+    name = "FromTemporalAccessor",
+    summary =
+        "Certain combinations of javaTimeType.from(TemporalAccessor) will always throw a"
+            + " DateTimeException or return the parameter directly.",
+    explanation =
+        "Not all java.time types can be created via from(TemporalAccessor). For example, you can"
+            + " create a Month from a LocalDate (Month.from(localDate)) because a LocalDate"
+            + " consists of a year, month, and day. However, you cannot create a LocalDate from a"
+            + " Month (since it doesn't have the year or day information). Instead of throwing a"
+            + " DateTimeException at runtime, this checker validates the type transformations at"
+            + " compile time using static type information.",
+    severity = ERROR)
+public final class FromTemporalAccessor extends BugChecker implements MethodInvocationTreeMatcher {
+
+  private static final String TEMPORAL_ACCESSOR = "java.time.temporal.TemporalAccessor";
+
+  private static final Matcher<ExpressionTree> FROM_MATCHER =
+      staticMethod().anyClass().named("from").withParameters(TEMPORAL_ACCESSOR);
+
+  private static final Matcher<ExpressionTree> PACKAGE_MATCHER =
+      anyOf(
+          packageStartsWith("java.time"),
+          packageStartsWith("org.threeten.extra"),
+          packageStartsWith("tck.java.time"));
+
+  private static final ImmutableListMultimap<Matcher<Tree>, Matcher<ExpressionTree>>
+      BAD_VALUE_FROM_KEY =
+          new ImmutableListMultimap.Builder<Matcher<Tree>, Matcher<ExpressionTree>>()
+              .putAll(
+                  makeKey(DayOfWeek.class),
+                  makeValues(
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(Instant.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(LocalDate.class),
+                  makeValues(
+                      Instant.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class))
+              .putAll(
+                  makeKey(LocalDateTime.class),
+                  makeValues(
+                      Instant.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class))
+              .putAll(
+                  makeKey(LocalTime.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(Month.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(MonthDay.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfYear.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(makeKey(OffsetDateTime.class), makeValues())
+              .putAll(
+                  makeKey(OffsetTime.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(Year.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(YearMonth.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      YearWeek.class))
+              .putAll(makeKey(ZonedDateTime.class), makeValues())
+              .putAll(
+                  makeKey(ZoneOffset.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(AmPm.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(DayOfMonth.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(DayOfYear.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(Quarter.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(YearQuarter.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(YearWeek.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class))
+              .build();
+
+  private static Matcher<Tree> makeKey(Class<?> keyClass) {
+    return isSameType(keyClass.getName());
+  }
+
+  private static List<Matcher<ExpressionTree>> makeValues(Class<?>... values) {
+    List<Matcher<ExpressionTree>> entries = new ArrayList<>();
+    for (Class<?> value : values) {
+      entries.add(
+          staticMethod().onClass(value.getName()).named("from").withParameters(TEMPORAL_ACCESSOR));
+    }
+    return entries;
+  }
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    // exit early if we're not in a `from(TemporalAccessor)` method
+    // this should be a large performance win since nearly all MITs will short-circuit here
+    if (!FROM_MATCHER.matches(tree, state)) {
+      return Description.NO_MATCH;
+    }
+
+    // exit early if we're inside java.time or ThreeTen-Extra
+    if (PACKAGE_MATCHER.matches(tree, state)) {
+      return Description.NO_MATCH;
+    }
+
+    // exit early if the receiver isn't a java.time or ThreeTen-Extra type
+    String receiverType = getReceiverType(tree).toString();
+    if (!receiverType.startsWith("java.time") && !receiverType.startsWith("org.threeten.extra")) {
+      return Description.NO_MATCH;
+    }
+
+    ExpressionTree arg0 = getOnlyElement(tree.getArguments());
+    Type type0 = getType(arg0);
+    // exit early if the parameter is statically typed as a TemporalAccessor
+    if (isSameType(type0, state.getTypeFromString(TEMPORAL_ACCESSOR), state)) {
+      return Description.NO_MATCH;
+    }
+
+    // prevent `Instant.from(instant)` and similar
+    if (isSameType(getType(tree), type0, state)) {
+      SuggestedFix.Builder builder = SuggestedFix.builder();
+      builder.replace(tree, state.getSourceForNode(arg0));
+      return describeMatch(tree, builder.build());
+    }
+
+    for (Map.Entry<Matcher<Tree>, Matcher<ExpressionTree>> entry : BAD_VALUE_FROM_KEY.entries()) {
+      Matcher<ExpressionTree> fromMatcher = entry.getValue(); // matches Type.from(TemporalAccessor)
+      Matcher<Tree> argumentMatcher = entry.getKey(); // ensures the arg0 is a "bad type"
+      if (fromMatcher.matches(tree, state) && argumentMatcher.matches(arg0, state)) {
+        return describeMatch(tree);
+      }
+    }
+    return Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/refaster/BlockTemplate.java
+++ b/core/src/main/java/com/google/errorprone/refaster/BlockTemplate.java
@@ -178,7 +178,7 @@ public abstract class BlockTemplate extends Template<BlockTemplateMatch> {
     try {
       pretty(context, writer).printStat(statement);
     } catch (IOException e) {
-      throw new AssertionError("StringWriter cannot throw IOExceptions");
+      throw new AssertionError("StringWriter cannot throw IOExceptions", e);
     }
     return writer.toString();
   }
@@ -192,7 +192,7 @@ public abstract class BlockTemplate extends Template<BlockTemplateMatch> {
     try {
       pretty(context, writer).printStats(com.sun.tools.javac.util.List.from(statements));
     } catch (IOException e) {
-      throw new AssertionError("StringWriter cannot throw IOExceptions");
+      throw new AssertionError("StringWriter cannot throw IOExceptions", e);
     }
     return writer.toString();
   }

--- a/core/src/main/java/com/google/errorprone/refaster/Inliner.java
+++ b/core/src/main/java/com/google/errorprone/refaster/Inliner.java
@@ -224,9 +224,12 @@ public final class Inliner {
     }
     Name name = asName(var.getName());
     TypeSymbol sym = new TypeVariableSymbol(0, name, null, symtab().noSymbol);
-    typeVar = new TypeVar(sym, var.getUpperBound().inline(this), var.getLowerBound().inline(this));
+    typeVar = new TypeVar(sym, /* bound= */ null, /* lower= */ symtab().botType);
     sym.type = typeVar;
     typeVarCache.put(var.getName(), typeVar);
+    // Any recursive uses of var will point to the same TypeVar object generated above.
+    JdkCompatHelper.setUpperBound(typeVar, var.getUpperBound().inline(this));
+    typeVar.lower = var.getLowerBound().inline(this);
     return typeVar;
   }
 

--- a/core/src/main/java/com/google/errorprone/refaster/JdkCompatHelper.java
+++ b/core/src/main/java/com/google/errorprone/refaster/JdkCompatHelper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster;
+
+import com.google.errorprone.refaster.PlaceholderUnificationVisitor.State;
+import com.sun.source.tree.CaseTree;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.Type.TypeVar;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCCase;
+
+/**
+ * Contains methods that need to be implemented differently in other JDK versions.
+ *
+ * <p>Those implementations are provided by specific copies of this class that will eventually to
+ * packaged in a Multi-Release JAR.
+ */
+class JdkCompatHelper {
+  static void setUpperBound(TypeVar typeVar, Type bound) {
+    // This field has been renamed and made private in JDK 13 in
+    // https://github.com/openjdk/jdk/commit/777ad9080e8a35229fe5110a3f1dbc6cc7e95a1d
+    // where it's replaced with a setUpperBound setter.
+    typeVar.bound = bound;
+  }
+
+  static Choice<State<JCCase>> unifyCase(
+      PlaceholderUnificationVisitor visitor, final CaseTree node, State<?> state) {
+    // JDK 12 introduces Switch Expressions in
+    // https://github.com/openjdk/jdk/commit/b3b644438e9e4d30a062e509d939d4b8e197a389
+    return PlaceholderUnificationVisitor.chooseSubtrees(
+        state,
+        s -> visitor.unifyStatements(node.getStatements(), s),
+        stmts -> visitor.maker().Case((JCTree.JCExpression) node.getExpression(), stmts));
+  }
+
+  private JdkCompatHelper() {}
+}

--- a/core/src/main/java/com/google/errorprone/refaster/PlaceholderUnificationVisitor.java
+++ b/core/src/main/java/com/google/errorprone/refaster/PlaceholderUnificationVisitor.java
@@ -308,14 +308,14 @@ abstract class PlaceholderUnificationVisitor
    *   <li>a function that takes pieces of a tree type and recomposes them
    * </ol>
    */
-  private static <T, R> Choice<State<R>> chooseSubtrees(
+  static <T, R> Choice<State<R>> chooseSubtrees(
       State<?> state,
       Function<State<?>, Choice<? extends State<? extends T>>> choice1,
       Function<T, R> finalizer) {
     return choice1.apply(state).transform(s -> s.withResult(finalizer.apply(s.result())));
   }
 
-  private static <T1, T2, R> Choice<State<R>> chooseSubtrees(
+  static <T1, T2, R> Choice<State<R>> chooseSubtrees(
       State<?> state,
       Function<State<?>, Choice<? extends State<? extends T1>>> choice1,
       Function<State<?>, Choice<? extends State<? extends T2>>> choice2,
@@ -330,11 +330,11 @@ abstract class PlaceholderUnificationVisitor
   }
 
   @FunctionalInterface
-  private interface TriFunction<T1, T2, T3, R> {
+  interface TriFunction<T1, T2, T3, R> {
     R apply(T1 t1, T2 t2, T3 t3);
   }
 
-  private static <T1, T2, T3, R> Choice<State<R>> chooseSubtrees(
+  static <T1, T2, T3, R> Choice<State<R>> chooseSubtrees(
       State<?> state,
       Function<State<?>, Choice<? extends State<? extends T1>>> choice1,
       Function<State<?>, Choice<? extends State<? extends T2>>> choice2,
@@ -358,11 +358,11 @@ abstract class PlaceholderUnificationVisitor
   }
 
   @FunctionalInterface
-  private interface QuadFunction<T1, T2, T3, T4, R> {
+  interface QuadFunction<T1, T2, T3, T4, R> {
     R apply(T1 t1, T2 t2, T3 t3, T4 t4);
   }
 
-  private static <T1, T2, T3, T4, R> Choice<State<R>> chooseSubtrees(
+  static <T1, T2, T3, T4, R> Choice<State<R>> chooseSubtrees(
       State<?> state,
       Function<State<?>, Choice<? extends State<? extends T1>>> choice1,
       Function<State<?>, Choice<? extends State<? extends T2>>> choice2,
@@ -662,11 +662,7 @@ abstract class PlaceholderUnificationVisitor
 
   @Override
   public Choice<State<JCCase>> visitCase(final CaseTree node, State<?> state) {
-    return chooseSubtrees(
-        state,
-        s -> unifyStatements(node.getStatements(), s),
-        s -> unify(node.getBody(), s),
-        (stmts, body) -> maker().Case(CaseTree.CaseKind.STATEMENT, List.<JCExpression>of((JCExpression) node.getExpression()), stmts, body));
+    return JdkCompatHelper.unifyCase(this, node, state);
   }
 
   @Override

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -291,6 +291,7 @@ import com.google.errorprone.bugpatterns.TransientMisuse;
 import com.google.errorprone.bugpatterns.TreeToString;
 import com.google.errorprone.bugpatterns.TruthAssertExpected;
 import com.google.errorprone.bugpatterns.TruthConstantAsserts;
+import com.google.errorprone.bugpatterns.TruthGetOrDefault;
 import com.google.errorprone.bugpatterns.TruthSelfEquals;
 import com.google.errorprone.bugpatterns.TryFailRefactoring;
 import com.google.errorprone.bugpatterns.TryFailThrowable;
@@ -812,6 +813,7 @@ public class BuiltInCheckerSuppliers {
           TreeToString.class,
           TruthAssertExpected.class,
           TruthConstantAsserts.class,
+          TruthGetOrDefault.class,
           TruthIncompatibleType.class,
           TypeEqualsChecker.class,
           TypeNameShadowing.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -422,6 +422,7 @@ import com.google.errorprone.bugpatterns.time.DurationFrom;
 import com.google.errorprone.bugpatterns.time.DurationGetTemporalUnit;
 import com.google.errorprone.bugpatterns.time.DurationTemporalUnit;
 import com.google.errorprone.bugpatterns.time.DurationToLongTimeUnit;
+import com.google.errorprone.bugpatterns.time.FromTemporalAccessor;
 import com.google.errorprone.bugpatterns.time.InstantTemporalUnit;
 import com.google.errorprone.bugpatterns.time.InvalidJavaTimeConstant;
 import com.google.errorprone.bugpatterns.time.JavaDurationGetSecondsGetNano;
@@ -539,6 +540,7 @@ public class BuiltInCheckerSuppliers {
           ForOverrideChecker.class,
           FormatString.class,
           FormatStringAnnotationChecker.class,
+          FromTemporalAccessor.class,
           FunctionalInterfaceMethodChanged.class,
           FuturesGetCheckedIllegalExceptionType.class,
           GetClassOnAnnotation.class,

--- a/core/src/main/java14/com/google/errorprone/refaster/JdkCompatHelper.java
+++ b/core/src/main/java14/com/google/errorprone/refaster/JdkCompatHelper.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster;
+
+import com.google.errorprone.refaster.PlaceholderUnificationVisitor.State;
+import com.sun.source.tree.CaseTree;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.Type.TypeVar;
+import com.sun.tools.javac.tree.JCTree.JCCase;
+import com.sun.tools.javac.tree.JCTree.JCExpression;
+import com.sun.tools.javac.util.List;
+
+/**
+ * Contains methods that need to be implemented differently in other JDK versions.
+ *
+ * <p>Those implementations are provided by specific copies of this class that will eventually to
+ * packaged in a Multi-Release JAR.
+ */
+class JdkCompatHelper {
+  static void setUpperBound(TypeVar typeVar, Type bound) {
+    // This field has been renamed and made private in JDK 13 in
+    // https://github.com/openjdk/jdk/commit/777ad9080e8a35229fe5110a3f1dbc6cc7e95a1d
+    // where it's replaced with a setUpperBound setter.
+    typeVar.setUpperBound(bound);
+  }
+
+  static Choice<State<JCCase>> unifyCase(
+      PlaceholderUnificationVisitor visitor, final CaseTree node, State<?> state) {
+    // JDK 12 introduces Switch Expressions in
+    // https://github.com/openjdk/jdk/commit/b3b644438e9e4d30a062e509d939d4b8e197a389
+    return PlaceholderUnificationVisitor.chooseSubtrees(
+        state,
+        s -> visitor.unifyStatements(node.getStatements(), s),
+        s -> visitor.unify(node.getBody(), s),
+        (stmts, body) ->
+            visitor
+                .maker()
+                .Case(
+                    CaseTree.CaseKind.STATEMENT,
+                    List.<JCExpression>of((JCExpression) node.getExpression()),
+                    stmts,
+                    body));
+  }
+
+  private JdkCompatHelper() {}
+}

--- a/core/src/main/java14/com/google/errorprone/refaster/UInstanceOf.java
+++ b/core/src/main/java14/com/google/errorprone/refaster/UInstanceOf.java
@@ -28,6 +28,10 @@ import javax.annotation.Nullable;
 /**
  * {@link UTree} representation of a {@link InstanceOfTree}.
  *
+ * <p>JDK 14 introduces {@link #getPattern()} for pattern matching for {@code instanceof} in <a
+ * href="https://github.com/openjdk/jdk/commit/229e0d16313b10932b9ce7506d84096696983699"
+ * >https://github.com/openjdk/jdk/commit/229e0d16313b10932b9ce7506d84096696983699</a>
+ *
  * @author lowasser@google.com (Louis Wasserman)
  */
 @AutoValue
@@ -36,6 +40,8 @@ abstract class UInstanceOf extends UExpression implements InstanceOfTree {
     return new AutoValue_UInstanceOf(null, expression, type);
   }
 
+  @Nullable
+  @Override
   public abstract JCPattern getPattern();
 
   @Override

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ArrayFillIncompatibleTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ArrayFillIncompatibleTypeTest.java
@@ -39,7 +39,7 @@ public class ArrayFillIncompatibleTypeTest {
             "     Arrays.fill(o, b);",
             "  }",
             "}")
-        .setArgs(Arrays.asList("-source", "1.6", "-target", "1.6"))
+        .setArgs(Arrays.asList("-source", "7", "-target", "7"))
         .doTest();
   }
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/EqualsIncompatibleTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/EqualsIncompatibleTypeTest.java
@@ -53,7 +53,7 @@ public class EqualsIncompatibleTypeTest {
             "     o.equals(b);",
             "  }",
             "}")
-        .setArgs(Arrays.asList("-source", "1.6", "-target", "1.6"))
+        .setArgs(Arrays.asList("-source", "7", "-target", "7"))
         .doTest();
   }
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/TruthGetOrDefaultTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/TruthGetOrDefaultTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link TruthGetOrDefault} bug pattern.
+ *
+ * @author bhagwani@google.com (Sumit Bhagwani)
+ */
+@RunWith(JUnit4.class)
+public class TruthGetOrDefaultTest {
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(TruthGetOrDefault.class, getClass());
+  private final BugCheckerRefactoringTestHelper testHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new TruthGetOrDefault(), getClass());
+
+  @Test
+  public void testPositiveCases() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import static com.google.common.truth.Truth.assertThat;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "class Test {",
+            "  void test() {",
+            "    Map<String, Integer> map = new HashMap<>();",
+            "    // BUG: Diagnostic contains: TruthGetOrDefault",
+            "    assertThat(map.getOrDefault(\"key\",  0)).isEqualTo(0);",
+            "    Integer expectedVal = 0;",
+            "    // BUG: Diagnostic contains: TruthGetOrDefault",
+            "    assertThat(map.getOrDefault(\"key\",  expectedVal)).isEqualTo(expectedVal);",
+            "    Map<String, Long> longMap = new HashMap<>();",
+            "    // BUG: Diagnostic contains: TruthGetOrDefault",
+            "    assertThat(longMap.getOrDefault(\"key\",  0L)).isEqualTo(5L);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testNegativeCases() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import static com.google.common.truth.Truth.assertThat;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "class Test {",
+            "  void test() {",
+            "    Map<String, Integer> map = new HashMap<>();",
+            "    Integer expectedVal = 10;",
+            "    assertThat(map.getOrDefault(\"key\",  0)).isEqualTo(expectedVal);",
+            "    assertThat(map.getOrDefault(\"key\",  Integer.valueOf(0)))",
+            "      .isEqualTo(Integer.valueOf(1));",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testFixGeneration() {
+    testHelper
+        .addInputLines(
+            "in/Test.java",
+            "import static com.google.common.truth.Truth.assertThat;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "class Test {",
+            "  void test() {",
+            "    Map<String, Integer> map = new HashMap<>();",
+            "    assertThat(map.getOrDefault(\"key\",  0)).isEqualTo(1);",
+            "    Map<String, Long> longMap = new HashMap<>();",
+            "    assertThat(longMap.getOrDefault(\"key\",  0L)).isEqualTo(0L);",
+            "    assertThat(longMap.getOrDefault(\"key\",  0L)).isEqualTo(0);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "import static com.google.common.truth.Truth.assertThat;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "class Test {",
+            "  void test() {",
+            "    Map<String, Integer> map = new HashMap<>();",
+            "    assertThat(map).containsEntry(\"key\", 1);",
+            "    Map<String, Long> longMap = new HashMap<>();",
+            "    assertThat(longMap).doesNotContainKey(\"key\");",
+            "    assertThat(longMap.getOrDefault(\"key\",  0L)).isEqualTo(0);",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualifiedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualifiedTest.java
@@ -48,7 +48,9 @@ public final class UnnecessarilyFullyQualifiedTest {
   @Test
   public void wouldBeAmbiguous() {
     helper
-        .addInputLines("List.java", "class List {}")
+        .addInputLines(
+            "List.java", //
+            "class List {}")
         .expectUnchanged()
         .addInputLines(
             "Test.java", //
@@ -73,6 +75,29 @@ public final class UnnecessarilyFullyQualifiedTest {
             "interface Test {",
             "  java.util.List foo();",
             "  a.List bar();",
+            "}")
+        .expectUnchanged()
+        .doTest();
+  }
+
+  @Test
+  public void clashesWithTypeInSuperType() {
+    helper
+        .addInputLines(
+            "A.java", //
+            "package a;",
+            "public interface A {",
+            "  public static class List {}",
+            "}")
+        .expectUnchanged()
+        .addInputLines(
+            "Test.java",
+            "package b;",
+            "import a.A;",
+            "class Test implements A {",
+            "  java.util.List foo() {",
+            "    return null;",
+            "  }",
             "}")
         .expectUnchanged()
         .doTest();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/testdata/MoreThanOneScopeAnnotationOnClassPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/testdata/MoreThanOneScopeAnnotationOnClassPositiveCases.java
@@ -26,14 +26,18 @@ public class MoreThanOneScopeAnnotationOnClassPositiveCases {
   /** Class has two scope annotations */
   @Singleton
   @SessionScoped
-  // BUG: Diagnostic contains: @Singleton(), @SessionScoped().
+  // BUG: Diagnostic contains:
+  // @Singleton
+  // @SessionScoped
   class TestClass1 {}
 
   /** Class has three annotations, two of which are scope annotations. */
   @Singleton
   @SuppressWarnings("foo")
   @SessionScoped
-  // BUG: Diagnostic contains: @Singleton(), @SessionScoped().
+  // BUG: Diagnostic contains:
+  // @Singleton
+  // @SessionScoped
   class TestClass2 {}
 
   @Scope
@@ -42,6 +46,9 @@ public class MoreThanOneScopeAnnotationOnClassPositiveCases {
   @Singleton
   @CustomScope
   @SessionScoped
-  // BUG: Diagnostic contains: @Singleton(), @CustomScope(), @SessionScoped().
+  // BUG: Diagnostic contains:
+  // @Singleton
+  // @CustomScope
+  // @SessionScoped
   class TestClass3 {}
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/FromTemporalAccessorTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/FromTemporalAccessorTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static com.google.common.base.StandardSystemProperty.JAVA_VERSION;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link FromTemporalAccessor}. */
+@RunWith(JUnit4.class)
+public class FromTemporalAccessorTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(FromTemporalAccessor.class, getClass());
+
+  @Test
+  public void typeFromTypeIsBad() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            // TODO(kak): Should we just use a wildcard import instead?
+            "import java.time.DayOfWeek;",
+            "import java.time.Instant;",
+            "import java.time.LocalDate;",
+            "import java.time.LocalDateTime;",
+            "import java.time.LocalTime;",
+            "import java.time.Month;",
+            "import java.time.MonthDay;",
+            "import java.time.OffsetDateTime;",
+            "import java.time.OffsetTime;",
+            "import java.time.Year;",
+            "import java.time.YearMonth;",
+            "import java.time.ZonedDateTime;",
+            "import java.time.ZoneOffset;",
+            "public class TestClass {",
+            "  void from(DayOfWeek value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    DayOfWeek.from(value);",
+            "  }",
+            "  void from(Instant value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    Instant.from(value);",
+            "  }",
+            "  void from(LocalDate value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    LocalDate.from(value);",
+            "  }",
+            "  void from(LocalDateTime value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    LocalDateTime.from(value);",
+            "  }",
+            "  void from(LocalTime value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    LocalTime.from(value);",
+            "  }",
+            "  void from(Month value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    Month.from(value);",
+            "  }",
+            "  void from(MonthDay value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    MonthDay.from(value);",
+            "  }",
+            "  void from(OffsetDateTime value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    OffsetDateTime.from(value);",
+            "  }",
+            "  void from(OffsetTime value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    OffsetTime.from(value);",
+            "  }",
+            "  void from(Year value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    Year.from(value);",
+            "  }",
+            "  void from(YearMonth value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    YearMonth.from(value);",
+            "  }",
+            "  void from(ZonedDateTime value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    ZonedDateTime.from(value);",
+            "  }",
+            "  void from(ZoneOffset value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    ZoneOffset.from(value);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeFromTemporalAccessor_knownGood() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.DayOfWeek;",
+            "import java.time.Instant;",
+            "import java.time.LocalDate;",
+            "import java.time.LocalDateTime;",
+            "import java.time.LocalTime;",
+            "import java.time.Month;",
+            "import java.time.MonthDay;",
+            "import java.time.OffsetDateTime;",
+            "import java.time.OffsetTime;",
+            "import java.time.Year;",
+            "import java.time.YearMonth;",
+            "import java.time.ZonedDateTime;",
+            "import java.time.ZoneOffset;",
+            "import java.time.temporal.TemporalAccessor;",
+            "public class TestClass {",
+            "  void from(TemporalAccessor value) {",
+            "    DayOfWeek.from(value);",
+            "    Instant.from(value);",
+            "    LocalDate.from(value);",
+            "    LocalDateTime.from(value);",
+            "    LocalTime.from(value);",
+            "    Month.from(value);",
+            "    MonthDay.from(value);",
+            "    OffsetDateTime.from(value);",
+            "    OffsetTime.from(value);",
+            "    Year.from(value);",
+            "    YearMonth.from(value);",
+            "    ZonedDateTime.from(value);",
+            "    ZoneOffset.from(value);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeFromType_knownGood() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.LocalDate;",
+            "import java.time.Year;",
+            "public class TestClass {",
+            "  void from(LocalDate value) {",
+            "    Year.from(value);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeFromType_threeTenExtra_knownGood() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.LocalTime;",
+            "import org.threeten.extra.AmPm;",
+            "public class TestClass {",
+            "  void from(LocalTime value) {",
+            "    AmPm.from(value);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeFromType_threeTenExtra_self() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import org.threeten.extra.AmPm;",
+            "public class TestClass {",
+            "  void from(AmPm value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    AmPm.from(value);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeFromType_customType() {
+    helper
+        .addSourceLines(
+            "Frobber.java",
+            "import java.time.DateTimeException;",
+            "import java.time.temporal.TemporalAccessor;",
+            "import java.time.temporal.TemporalField;",
+            "public class Frobber implements TemporalAccessor {",
+            "  static Frobber from(TemporalAccessor temporalAccessor) {",
+            "    if (temporalAccessor instanceof Frobber) {",
+            "      return (Frobber) temporalAccessor;",
+            "    }",
+            "    throw new DateTimeException(\"failure\");",
+            "  }",
+            "  @Override public long getLong(TemporalField field) { return 0; }",
+            "  @Override public boolean isSupported(TemporalField field) { return false; }",
+            "}")
+        .addSourceLines(
+            "TestClass.java",
+            "public class TestClass {",
+            "  void from(Frobber value) {",
+            "    Frobber frobber = Frobber.from(value);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeFromType_knownBadConversions() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.LocalDate;",
+            "import java.time.LocalDateTime;",
+            "import org.threeten.extra.Quarter;",
+            "public class TestClass {",
+            "  void from(LocalDate localDate, Quarter quarter) {",
+            "    // BUG: Diagnostic contains: FromTemporalAccessor",
+            "    LocalDateTime.from(localDate);",
+            "    // BUG: Diagnostic contains: FromTemporalAccessor",
+            "    LocalDateTime.from(quarter);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeFromType_knownBadConversions_insideJavaTime() {
+    // this test doesn't pass under JDK11 because of modules
+    if (JAVA_VERSION.value().startsWith("1.")) {
+      helper
+          .addSourceLines(
+              "TestClass.java",
+              "package java.time;",
+              "import java.time.LocalDate;",
+              "import java.time.LocalDateTime;",
+              "public class TestClass {",
+              "  void from(LocalDate localDate) {",
+              "    LocalDateTime.from(localDate);",
+              "  }",
+              "}")
+          .doTest();
+    }
+  }
+
+  @Test
+  public void typeFromType_knownBadConversions_insideThreeTenExtra() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "package org.threeten.extra;",
+            "import java.time.LocalDateTime;",
+            "public class TestClass {",
+            "  void from(Quarter quarter) {",
+            "    LocalDateTime.from(quarter);",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/docs/bugpattern/TruthGetOrDefault.md
+++ b/docs/bugpattern/TruthGetOrDefault.md
@@ -1,0 +1,28 @@
+Expectation of `Truth.assertThat(map.getOrDefault(key,
+defaultValue)).isEqualTo(expectedValue)` is unclear if the `defaultValue` is
+same as `expectedValue`. If the test passes, its hard to say if `map` contained
+`key, expectedValue` as an entry. Most likely, developer intended to verify that
+`map` doesn't contain `'key` or perhaps map `key` isn't mapped to
+`defaultValue`.
+
+Additionally, same assertion can be simplified if `defaultValue` and
+`expectedValue` are different constants to
+`Truth.assertThat(map.get(key)).isEqualTo(expectedValue)`.
+
+That is, prefer this:
+
+```java
+public static void doSomething(Map<String, String> map, String key, String expectedValue) {
+  assertThat(map.get(key)).isEqualTo(expectedValue);
+  assertThat(map).doesNotContainKey(key);
+  assertThat(map).containsEntry(key, expectedValue);
+}
+```
+
+to this:
+
+```java
+public static void doSomething(Map<String, String> map, String key, String defaultValue, String expectedValue) {
+  assertThat(map.getOrDefault(key, defaultValue)).isEqualTo(expectedValue);
+}
+```

--- a/pom.xml
+++ b/pom.xml
@@ -175,4 +175,24 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <!-- for JDK 9+, adds -release 8 to make sure everything compiles against JDK 8 APIs -->
+      <id>jdk9+</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <release>8</release>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,9 @@
           </configuration>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.19.1</version>
           <configuration>
             <runOrder>alphabetical</runOrder>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,8 @@
     <compile.testing.version>0.18</compile.testing.version>
     <caffeine.version>2.7.0</caffeine.version>
     <java14.sourceDirectory>${project.basedir}/src/main/java14</java14.sourceDirectory>
-    <java14.build.outputDirectory>${project.build.directory}/classes-java14</java14.build.outputDirectory>
+    <java14.build.outputDirectory>${project.build.outputDirectory}/META-INF/versions/14</java14.build.outputDirectory>
+    <java14.generatedSourcesDirectory>${project.build.directory}/generated-sources/annotations-java14</java14.generatedSourcesDirectory>
   </properties>
 
   <modules>
@@ -112,13 +113,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>2.5</version>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Multi-Release>true</Multi-Release>
-            </manifestEntries>
-          </archive>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,14 @@
             <runOrder>alphabetical</runOrder>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>2.19.1</version>
+          <configuration>
+            <runOrder>alphabetical</runOrder>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>

--- a/test_helpers/pom.xml
+++ b/test_helpers/pom.xml
@@ -154,7 +154,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
         <configuration>
           <!-- set heap size to work around http://github.com/travis-ci/travis-ci/issues/3396 -->
           <argLine>-Xmx1g</argLine>
@@ -174,7 +173,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.19.1</version>
             <configuration>
               <!-- set heap size to work around http://github.com/travis-ci/travis-ci/issues/3396 -->
               <!-- put javac.jar on bootclasspath when executing tests -->


### PR DESCRIPTION
Fixed some tests (due to changes in the JDK)

Some tests still fail with JDK 14 though (due to similar changes in the JDK apparently).

Also minimized code duplication by extracting code that need JDK-specific implementations into a helper class.